### PR TITLE
オプション-aに対応

### DIFF
--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -2,22 +2,19 @@ require 'optparse'
 require 'debug'
 
 def main
-  judge_option
-  get_deta
-  make_array
-  show_files
+  current_dir = get_deta
+  arrays = make_array(current_dir)
+  show_files(arrays)
 end
 
-def judge_option
+def get_deta
   @options = {}
   OptionParser.new do |opt|
     opt.on('-a', '--all', 'do not ignore entries starting with .'){ |v| @options[:a] = v }
     #オプションをここに追加していく予定です
     opt.parse!(ARGV)
   end
-end
 
-def get_deta
   if @options.has_key?(:a)
     Dir.glob("*", File::FNM_DOTMATCH)
   else
@@ -26,8 +23,7 @@ def get_deta
 end
 
 MAX_ROW = 3.0
-def make_array
-  current_dir = get_deta
+def make_array(current_dir)
   total_file_size = current_dir.size
   columns = (total_file_size / MAX_ROW).ceil
   arrays = []
@@ -42,8 +38,8 @@ def make_array
   end
 end
 
-def show_files
-  transposed_array = make_array.transpose
+def show_files(arrays)
+  transposed_array = arrays.transpose
   transposed_array.each do |two_dimensional_array|
     two_dimensional_array.each do |file|
       print "#{file}".ljust(25)

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -29,8 +29,8 @@ def create_and_show_files_list(all_files)
 
   rest_of_row = all_files.size % COLUMN_NUMBER
 
-  max_text_length = all_files.compact.max_by(&:size).size + SPACE
-  formd_file = all_files.map {|space| space.to_s.ljust(max_text_length)}
+  max_column_width = all_files.compact.max_by(&:size).size + SPACE
+  formd_file = all_files.map {|space| space.to_s.ljust(max_column_width)}
   (row * COLUMN_NUMBER - all_files.size).times {formd_file.push(nil)} if rest_of_row != 0
   file_index = formd_file.each_slice(row).to_a
 

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -1,8 +1,10 @@
 require 'optparse'
 require 'debug'
+require 'nkf'
+
 
 def main
-  current_dir = get_deta
+  current_dir =  get_deta
   arrays = make_array(current_dir)
   show_files(arrays)
 end
@@ -37,10 +39,18 @@ def make_array(current_dir)
   end
 end
 
+class String
+  def mb_ljust(width, padding=' ')
+    output_width = each_char.map{|c| c.bytesize == 1 ? 1 : 2}.reduce(0, &:+)
+    padding_size = [0, width - output_width].max
+    self + padding * padding_size
+  end
+end
+
 def show_files(arrays)
   arrays.transpose.each do |two_dimensional_array|
     two_dimensional_array.each do |file|
-      print "#{file}".ljust(25)
+      print "#{file}".mb_ljust(25,' ')
     end
     print  "\n"
   end

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -6,7 +6,6 @@ def main
   create_and_show_files_list(all_files)
 end
 
-
 def get_files_name
   options = {}
   OptionParser.new do |opt|
@@ -26,11 +25,13 @@ COLUMN_NUMBER = 3
 SPACE = 5
 
 def create_and_show_files_list(all_files)
-  row = (all_files.size / COLUMN_NUMBER).ceil
+  row = (all_files.size.to_f / COLUMN_NUMBER).ceil
+  p row
   rest_of_row = all_files.size % COLUMN_NUMBER
+  p rest_of_row
   max_text_length = all_files.compact.max_by(&:size).size + SPACE
   formd_file = all_files.map {|space| space.to_s.ljust(max_text_length)}
-  (row -  rest_of_row).times {formd_file.push(nil)} if rest_of_row != 0
+  (row * COLUMN_NUMBER - all_files.size).times {formd_file.push(nil)} if rest_of_row != 0
   file_index = formd_file.each_slice(row).to_a
   
   file_index.transpose.each do |index| 

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -25,14 +25,14 @@ COLUMN_NUMBER = 3
 SPACE = 5
 
 def create_and_show_files_list(all_files)
-  row = (all_files.size.to_f / COLUMN_NUMBER).ceil
+  display_row_number = (all_files.size.to_f / COLUMN_NUMBER).ceil
 
   rest_of_row = all_files.size % COLUMN_NUMBER
 
   max_column_width = all_files.compact.max_by(&:size).size + SPACE
   formd_file = all_files.map {|space| space.to_s.ljust(max_column_width)}
-  (row * COLUMN_NUMBER - all_files.size).times {formd_file.push(nil)} if rest_of_row != 0
-  file_index = formd_file.each_slice(row).to_a
+  (display_row_number * COLUMN_NUMBER - all_files.size).times {formd_file.push(nil)} if rest_of_row != 0
+  file_index = formd_file.each_slice(display_row_number).to_a
 
   file_index.transpose.each do |index|
     puts index.join

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -10,7 +10,7 @@ def get_files_name
   options = {}
   OptionParser.new do |opt|
     opt.on('-a', '--all', 'do not ignore entries starting with .'){ |v| options[:a] = v }
-    #オプションをここに追加していく予定です
+    # オプションをここに追加していく予定です
     opt.parse!(ARGV)
   end
 
@@ -30,11 +30,11 @@ def create_and_show_files_list(all_files)
   rest_of_row = all_files.size % COLUMN_NUMBER
 
   max_column_width = all_files.compact.max_by(&:size).size + SPACE
-  formd_file = all_files.map {|space| space.to_s.ljust(max_column_width)}
-  (display_row_number * COLUMN_NUMBER - all_files.size).times {formd_file.push(nil)} if rest_of_row != 0
-   set_of_files_arrays = formd_file.each_slice(display_row_number).to_a
+  file_and_space = all_files.map {|space| space.to_s.ljust(max_column_width)}
+  (display_row_number * COLUMN_NUMBER - all_files.size).times {file_and_space.push(nil)} if rest_of_row != 0
+  set_of_files_arrays = file_and_space.each_slice(display_row_number).to_a
 
-   set_of_files_arrays.transpose.each do |index|
+  set_of_files_arrays.transpose.each do |index|
     puts index.join
   end
 end

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -41,3 +41,4 @@ def create_and_show_files_list(all_files)
 end
 
 main
+ 

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -22,17 +22,18 @@ def get_files_name
   end
 end
 
-MAX_COLUMN_NUMBER = 3
+COLUMN_NUMBER = 3
+SPACE = 5
 
 def create_and_show_files_list(all_files)
-  columns_number = (all_files.size / MAX_COLUMN_NUMBER).ceil
-  all_files.push(nil) while all_files.size % MAX_COLUMN_NUMBER != 0
-  file_index = all_files.each_slice(MAX_COLUMN_NUMBER).to_a.transpose
-
-  space = 5
-  max_text_length = all_files.compact.max_by(&:size).size + space
+  row = (all_files.size / COLUMN_NUMBER).ceil
+  rest_of_row = all_files.size % COLUMN_NUMBER
+  (row - rest_of_row).times {all_files.push(nil)} if rest_of_row != 0
+  file_index = all_files.each_slice(row).to_a
+  max_text_length = all_files.compact.max_by(&:size).size + SPACE
+  files = file_index.transpose
   
-  file_index.transpose.each do |index| 
+  files.each do |index| 
     index.each do |file|
       print "#{file}".ljust(max_text_length)
     end

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -32,9 +32,9 @@ def create_and_show_files_list(all_files)
   max_column_width = all_files.compact.max_by(&:size).size + SPACE
   formd_file = all_files.map {|space| space.to_s.ljust(max_column_width)}
   (display_row_number * COLUMN_NUMBER - all_files.size).times {formd_file.push(nil)} if rest_of_row != 0
-  file_index = formd_file.each_slice(display_row_number).to_a
+   set_of_files_arrays = formd_file.each_slice(display_row_number).to_a
 
-  file_index.transpose.each do |index|
+   set_of_files_arrays.transpose.each do |index|
     puts index.join
   end
 end

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -8,14 +8,14 @@ def main
 end
 
 def get_deta
-  @options = {}
+  options = {}
   OptionParser.new do |opt|
-    opt.on('-a', '--all', 'do not ignore entries starting with .'){ |v| @options[:a] = v }
+    opt.on('-a', '--all', 'do not ignore entries starting with .'){ |v| options[:a] = v }
     #オプションをここに追加していく予定です
     opt.parse!(ARGV)
   end
 
-  if @options.has_key?(:a)
+  if options.has_key?(:a)
     Dir.glob("*", File::FNM_DOTMATCH)
   else
     Dir.glob("*").sort
@@ -24,10 +24,9 @@ end
 
 MAX_ROW = 3.0
 def make_array(current_dir)
-  total_file_size = current_dir.size
-  columns = (total_file_size / MAX_ROW).ceil
+  columns = (current_dir.size / MAX_ROW).ceil
   arrays = []
-  if total_file_size.zero?
+  if current_dir.size.zero?
     arrays
   else
     current_dir.each_slice(columns) do |list_of_file|
@@ -39,8 +38,7 @@ def make_array(current_dir)
 end
 
 def show_files(arrays)
-  transposed_array = arrays.transpose
-  transposed_array.each do |two_dimensional_array|
+  arrays.transpose.each do |two_dimensional_array|
     two_dimensional_array.each do |file|
       print "#{file}".ljust(25)
     end

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -2,13 +2,27 @@ require 'optparse'
 require 'debug'
 
 def main
+  judge_option
   get_deta
   make_array
   show_files
 end
 
+def judge_option
+  @options = {}
+  OptionParser.new do |opt|
+    opt.on('-a', '--all', 'do not ignore entries starting with .'){ |v| @options[:a] = v }
+    #オプションをここに追加していく予定です
+    opt.parse!(ARGV)
+  end
+end
+
 def get_deta
-  Dir.glob("*").sort
+  if @options.has_key?(:a)
+    Dir.glob("*", File::FNM_DOTMATCH)
+  else
+    Dir.glob("*").sort
+  end
 end
 
 MAX_ROW = 3.0

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -1,15 +1,13 @@
 require 'optparse'
 require 'debug'
-require 'nkf'
-
 
 def main
-  current_dir =  get_deta
-  arrays = make_array(current_dir)
-  show_files(arrays)
+  all_files = get_files_name
+  create_and_show_files_list(all_files)
 end
 
-def get_deta
+
+def get_files_name
   options = {}
   OptionParser.new do |opt|
     opt.on('-a', '--all', 'do not ignore entries starting with .'){ |v| options[:a] = v }
@@ -24,25 +22,19 @@ def get_deta
   end
 end
 
-MAX_ROW = 3.0
-def make_array(current_dir)
-  columns = (current_dir.size / MAX_ROW).ceil
-  arrays = []
-  if current_dir.size.zero?
-    arrays
-  else
-    current_dir.each_slice(columns) do |list_of_file|
-      arrays << list_of_file
-    end
-    max_size = arrays.map(&:size).max
-    arrays.map! { |element| element.values_at(0...max_size) }
-  end
-end
+MAX_COLUMN_NUMBER = 3
 
-def show_files(arrays)
-  arrays.transpose.each do |two_dimensional_array|
-    two_dimensional_array.each do |file|
-      print "#{file}".ljust(25,' ')
+def create_and_show_files_list(all_files)
+  columns_number = (all_files.size / MAX_COLUMN_NUMBER).ceil
+  all_files.push(nil) while all_files.size % MAX_COLUMN_NUMBER != 0
+  file_index = all_files.each_slice(MAX_COLUMN_NUMBER).to_a.transpose
+
+  space = 5
+  max_text_length = all_files.compact.max_by(&:size).size + space
+  
+  file_index.transpose.each do |index| 
+    index.each do |file|
+      print "#{file}".ljust(max_text_length)
     end
     print  "\n"
   end

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -28,16 +28,13 @@ SPACE = 5
 def create_and_show_files_list(all_files)
   row = (all_files.size / COLUMN_NUMBER).ceil
   rest_of_row = all_files.size % COLUMN_NUMBER
-  (row - rest_of_row).times {all_files.push(nil)} if rest_of_row != 0
-  file_index = all_files.each_slice(row).to_a
   max_text_length = all_files.compact.max_by(&:size).size + SPACE
-  files = file_index.transpose
+  formd_file = all_files.map {|space| space.to_s.ljust(max_text_length)}
+  (row -  rest_of_row).times {formd_file.push(nil)} if rest_of_row != 0
+  file_index = formd_file.each_slice(row).to_a
   
-  files.each do |index| 
-    index.each do |file|
-      print "#{file}".ljust(max_text_length)
-    end
-    print  "\n"
+  file_index.transpose.each do |index| 
+    puts index.join
   end
 end
 

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -26,18 +26,17 @@ SPACE = 5
 
 def create_and_show_files_list(all_files)
   row = (all_files.size.to_f / COLUMN_NUMBER).ceil
-  p row
+
   rest_of_row = all_files.size % COLUMN_NUMBER
-  p rest_of_row
+
   max_text_length = all_files.compact.max_by(&:size).size + SPACE
   formd_file = all_files.map {|space| space.to_s.ljust(max_text_length)}
   (row * COLUMN_NUMBER - all_files.size).times {formd_file.push(nil)} if rest_of_row != 0
   file_index = formd_file.each_slice(row).to_a
-  
-  file_index.transpose.each do |index| 
+
+  file_index.transpose.each do |index|
     puts index.join
   end
 end
 
 main
- 

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -39,18 +39,10 @@ def make_array(current_dir)
   end
 end
 
-class String
-  def mb_ljust(width, padding=' ')
-    output_width = each_char.map{|c| c.bytesize == 1 ? 1 : 2}.reduce(0, &:+)
-    padding_size = [0, width - output_width].max
-    self + padding * padding_size
-  end
-end
-
 def show_files(arrays)
   arrays.transpose.each do |two_dimensional_array|
     two_dimensional_array.each do |file|
-      print "#{file}".mb_ljust(25,' ')
+      print "#{file}".ljust(25,' ')
     end
     print  "\n"
   end


### PR DESCRIPTION
lsコマンドの-a(全てのフォルダを表示する機能）オプションを追加しました🤩

質問が１点あります。

lsコマンド１の時には気づかなかったのですが、
表示するフォルダ名に日本と英字両方がある場合、サイズの判断を現状「全角（日本語）」と「半角（英数字）」を判断していない状態です。
```ruby
p "いろは".size      #=> 3
p "abc".size      #=> 3
```
そのため、半角も全角もいずれも同じサイズと判断して表示させるため、
フォルダ名の中に日本語と英語のが混在すると表示がずれます。
このように↓
<img width="673" alt="スクリーンショット 2022-06-01 13 05 10" src="https://user-images.githubusercontent.com/90853054/171405454-b3d36e44-0eda-4399-9184-4fead5860a5d.png">

ただし英字のみのファイルだと問題ないです。
このように↓
<img width="515" alt="スクリーンショット 2022-06-01 14 19 55" src="https://user-images.githubusercontent.com/90853054/171405563-a5f8a3bb-e56c-4bac-a509-3340d333eed5.png">

リファレンスを読んで「多言語化と文字列のエンコーディング」が原因だと特定したのですが
多言語化はした方が良いことなのか、何か他に余計な要素が考えられて
今回は考えなくて良いことなのかアドバイスをもらえませんか？💦

現状は多言語化には対応していない状態です。

よろしくお願いします🙏🏻