### PR TITLE
wcコマンド

### DIFF
--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -5,10 +5,6 @@ require 'debug'
 require 'date'
 
 def main
-  judje_options
-end
-
-def judje_options
   options = {}
   OptionParser.new do |opt|
     opt.on('-l', '--long', 'long list') { |v| options[:l] = v }
@@ -21,6 +17,7 @@ def judje_options
     print_without_option_l
   end
 end
+
 
 def print_option_l
   stat_file = Dir.glob('*').map { |s| File::Stat.new(s) }

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -1,6 +1,7 @@
 require 'optparse'
 require 'debug'
 
+# ls４ブランチを作成
 def main
   get_deta
   make_array

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -34,10 +34,10 @@ def print_option_l
   filetype_short = filetype_long.map! { |short| filetype_convert_name[short] }
 
   permission_num = stat_file.map(&:mode)
-  octal_permission = permission_num.map.each do |num|
+  octal_permission = permission_num.map do |num|
     num.to_s(8).to_i % 1000
   end
-  octal_permission.map(&:to_s)
+  octal_permission.map!(&:to_s)
   permission = octal_permission.map do |a|
     a.gsub(/[0-7]/, '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx', '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx')
   end

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -18,7 +18,6 @@ def main
   end
 end
 
-
 def print_option_l
   stat_file = Dir.glob('*').map { |s| File::Stat.new(s) }
 

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -14,7 +14,7 @@ end
 def option_parse
   options = {}
   OptionParser.new do |opt|
-    opt.on('-l', '--long', 'long list') { |v|options[:l] = v}
+    opt.on('-l', '--long', 'long list') { |v| options[:l] = v }
     opt.parse!(ARGV)
   end
   options
@@ -29,14 +29,14 @@ def print_long_filename(stat_file)
   stat_file.each_with_index do |convert, num|
     filetype(convert)
     permission(convert)
-    hardlink(stat_file,convert)
+    hardlink(stat_file, convert)
     user(convert)
     group(convert)
-    filesize(stat_file,convert)
+    filesize(stat_file, convert)
     timestamp(convert)
     filename(num)
-    puts "#{filetype(convert)}#{permission(convert)} #{hardlink(stat_file,convert)}\
-    #{user(convert)} #{group(convert)}  #{filesize(stat_file,convert)} #{timestamp(convert)} #{filename(num)} "
+    puts "#{filetype(convert)}#{permission(convert)} #{hardlink(stat_file, convert)}\
+    #{user(convert)} #{group(convert)}  #{filesize(stat_file, convert)} #{timestamp(convert)} #{filename(num)} "
   end
 end
 
@@ -56,7 +56,7 @@ def permission(convert)
   octal_permission.to_s.gsub(/[0-7]/, '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx', '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx')
 end
 
-def hardlink(stat_file,convert)
+def hardlink(stat_file, convert)
   max_lenth = stat_file.map(&:nlink).max.to_s.bytesize
   convert.nlink.to_s.rjust(max_lenth)
 end
@@ -71,7 +71,7 @@ def group(convert)
   Etc.getgrgid(group_id).name
 end
 
-def filesize(stat_file,convert)
+def filesize(stat_file, convert)
   max_lenth = stat_file.map(&:size).max.to_s.bytesize
   convert.size.to_s.rjust(max_lenth)
 end

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -29,13 +29,13 @@ def print_option_l
 
   filetype_long = stat_file.map(&:ftype)
   filetype_convert_name = {'fifo' => 'p', 'characterSpecial' => 'c', 'directory' => 'd', 'blockSpecial' => 'b', 'file' => '-', 'link' => 'l', 'socket' => 's'}.freeze
-  filetype_short = filetype_long.map!{|n| filetype_convert_name[n]  }
+  filetype_short = filetype_long.map!{|short| filetype_convert_name[short]  }
 
   permission_num = stat_file.map(&:mode)
-  octal_permission = permission_num.map.each do |n|
-    n.to_s(8).to_i % 1000
+  octal_permission = permission_num.map.each do |num|
+    num.to_s(8).to_i % 1000
   end
-  octal_permission.map!{|i| i.to_s}
+  octal_permission.map!{|oct| oct.to_s}
   permission = octal_permission.map{ |a| a.gsub(/[0-7]/, '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx', '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx') }
   max_permission_width = permission.compact.max_by(&:size).size  + 1
   permission.map! {|space| space.to_s.ljust(max_permission_width)}
@@ -57,7 +57,6 @@ def print_option_l
   time_stamp = get_time.map{|time| time.strftime('%_m %_d %_R').to_s.ljust(12)} 
   time_stamp.map! {|space| space.to_s.ljust(10)}
 
-  symbolic_link = stat_file.map(&:symlink?)
   name = Dir.glob("*")
   max_name_width = name.compact.max_by(&:size).size  + 1
   name.map! {|space| space.to_s.ljust(max_name_width)}

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'optparse'
 require 'debug'
 require 'date'
@@ -9,11 +11,11 @@ end
 def judje_options
   options = {}
   OptionParser.new do |opt|
-    opt.on('-l', '--long', 'long list'){ |v| options[:l] = v }
+    opt.on('-l', '--long', 'long list') { |v| options[:l] = v }
     opt.parse!(ARGV)
   end
 
-  if options.has_key?(:l)
+  if options.key?(:l)
     print_option_l
   else
     print_without_option_l
@@ -21,45 +23,47 @@ def judje_options
 end
 
 def print_option_l
-  stat_file = Dir.glob("*").map { |s| File::Stat.new(s) }
+  stat_file = Dir.glob('*').map { |s| File::Stat.new(s) }
 
   total_blocks = stat_file.map(&:blocks)
   puts "total #{total_blocks.sum}"
 
-
   filetype_long = stat_file.map(&:ftype)
-  filetype_convert_name = {'fifo' => 'p', 'characterSpecial' => 'c', 'directory' => 'd', 'blockSpecial' => 'b', 'file' => '-', 'link' => 'l', 'socket' => 's'}.freeze
-  filetype_short = filetype_long.map!{|short| filetype_convert_name[short]  }
+  filetype_convert_name = { 'fifo' => 'p', 'characterSpecial' => 'c', 'directory' => 'd', 'blockSpecial' => 'b', 'file' => '-', 'link' => 'l',
+                            'socket' => 's' }.freeze
+  filetype_short = filetype_long.map! { |short| filetype_convert_name[short] }
 
   permission_num = stat_file.map(&:mode)
   octal_permission = permission_num.map.each do |num|
     num.to_s(8).to_i % 1000
   end
-  octal_permission.map!{|oct| oct.to_s}
-  permission = octal_permission.map{ |a| a.gsub(/[0-7]/, '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx', '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx') }
-  max_permission_width = permission.compact.max_by(&:size).size  + 1
-  permission.map! {|space| space.to_s.ljust(max_permission_width)}
+  octal_permission.map(&:to_s)
+  permission = octal_permission.map do |a|
+    a.gsub(/[0-7]/, '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx', '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx')
+  end
+  max_permission_width = permission.compact.max_by(&:size).size + 1
+  permission.map! { |space| space.to_s.ljust(max_permission_width) }
 
   hardlink = stat_file.map(&:nlink)
-  hardlink.map! {|space| space.to_s.ljust(3)}
+  hardlink.map! { |space| space.to_s.ljust(3) }
 
   user_id = stat_file.map(&:uid)
-  owner_name = user_id.map{|u|Etc.getpwuid(u).name}
-  owner_name.map! {|space| space.to_s.ljust(7)}
+  owner_name = user_id.map { |u| Etc.getpwuid(u).name }
+  owner_name.map! { |space| space.to_s.ljust(7) }
   group_id = stat_file.map(&:gid)
-  group_name = group_id.map{|u|Etc.getgrgid(u).name}
-  group_name.map! {|space| space.to_s.ljust(7)}
+  group_name = group_id.map { |u| Etc.getgrgid(u).name }
+  group_name.map! { |space| space.to_s.ljust(7) }
 
   file_byte_size = stat_file.map(&:size)
-  file_byte_size.map! {|space| space.to_s.ljust(5)}
+  file_byte_size.map! { |space| space.to_s.ljust(5) }
 
   get_time = stat_file.map(&:mtime)
-  time_stamp = get_time.map{|time| time.strftime('%_m %_d %_R').to_s.ljust(12)} 
-  time_stamp.map! {|space| space.to_s.ljust(10)}
+  time_stamp = get_time.map { |time| time.strftime('%_m %_d %_R').to_s.ljust(12) }
+  time_stamp.map! { |space| space.to_s.ljust(10) }
 
-  name = Dir.glob("*")
-  max_name_width = name.compact.max_by(&:size).size  + 1
-  name.map! {|space| space.to_s.ljust(max_name_width)}
+  name = Dir.glob('*')
+  max_name_width = name.compact.max_by(&:size).size + 1
+  name.map! { |space| space.to_s.ljust(max_name_width) }
 
   filetype_short.zip(permission, hardlink, owner_name, group_name, file_byte_size, time_stamp, name) { |ary| puts ary.join }
 end
@@ -68,14 +72,14 @@ COLUMN_NUMBER = 3
 SPACE = 5
 
 def print_without_option_l
-  all_files = Dir.glob("*").sort
+  all_files = Dir.glob('*').sort
   display_row_number = (all_files.size.to_f / COLUMN_NUMBER).ceil
 
   rest_of_row = all_files.size % COLUMN_NUMBER
 
   max_column_width = all_files.compact.max_by(&:size).size + SPACE
-  formatted_content_names = all_files.map {|space| space.to_s.ljust(max_column_width)}
-  (display_row_number * COLUMN_NUMBER - all_files.size).times {formatted_content_names.push(nil)} if rest_of_row != 0
+  formatted_content_names = all_files.map { |space| space.to_s.ljust(max_column_width) }
+  (display_row_number * COLUMN_NUMBER - all_files.size).times { formatted_content_names.push(nil) } if rest_of_row != 0
   set_of_files_arrays = formatted_content_names.each_slice(display_row_number).to_a
 
   set_of_files_arrays.transpose.each do |index|

--- a/05.ls/ls_ver2.rb
+++ b/05.ls/ls_ver2.rb
@@ -9,7 +9,7 @@ end
 def judje_options
   options = {}
   OptionParser.new do |opt|
-    opt.on('-l', '--long', 'long display'){ |v| options[:l] = v }
+    opt.on('-l', '--long', 'long list'){ |v| options[:l] = v }
     opt.parse!(ARGV)
   end
 

--- a/06.wc/1.rb
+++ b/06.wc/1.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'debug'
+require 'date'
+
+COLUMN_NUMBER = 3
+SPACE = 5
+
+def main(**options)
+  files = options[:a] ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+  files = options[:r] ? files.reverse! : files
+  options.key?(:l) ? print_long_filename(files) : print_short_filename(files)
+end
+
+def option_parse
+  options = {}
+  OptionParser.new do |opt|
+    opt.on('-l', '--long', 'long list') { |v| options[:l] = v }
+    opt.on('-a', '--all', 'do not ignore entries starting with .') { |v| options[:a] = v }
+    opt.on('-r', 'reverse', 'reverse the sort order') { |v| options[:r] = v }
+    opt.parse!(ARGV)
+  end
+  options
+end
+
+def print_long_filename(files)
+  stat_file = files.map { |s| File::Stat.new(s) }
+  print_total_blocks(stat_file) if stat_file.size > 1
+  stat_file.each_with_index do |convert, num|
+    filetype(convert)
+    permission(convert)
+    hardlink(stat_file, convert)
+    user(convert)
+    group(convert)
+    filesize(stat_file, convert)
+    timestamp(convert)
+    filename(files, num)
+    puts "#{filetype(convert)}#{permission(convert)} #{hardlink(stat_file, convert)}\
+    #{user(convert)} #{group(convert)}  #{filesize(stat_file, convert)} #{timestamp(convert)} #{filename(files, num)} "
+  end
+end
+
+def print_total_blocks(stat_file)
+  puts "total #{stat_file.map(&:blocks).sum}"
+end
+
+def filetype(convert)
+  filetype_name = convert.ftype
+  filetype_convert_name = { 'fifo' => 'p', 'characterSpecial' => 'c', 'directory' => 'd', 'blockSpecial' => 'b', 'file' => '-', 'link' => 'l',
+                            'socket' => 's' }.freeze
+  filetype_convert_name[filetype_name]
+end
+
+def permission(convert)
+  octal_permission = convert.mode.to_s(8).to_i % 1000
+  octal_permission.to_s.gsub(/[0-7]/, '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx', '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx')
+end
+
+def hardlink(stat_file, convert)
+  max_lenth = stat_file.map(&:nlink).max.to_s.bytesize
+  convert.nlink.to_s.rjust(max_lenth)
+end
+
+def user(convert)
+  user_id = convert.uid
+  Etc.getpwuid(user_id).name
+end
+
+def group(convert)
+  group_id = convert.gid
+  Etc.getgrgid(group_id).name
+end
+
+def filesize(stat_file, convert)
+  max_lenth = stat_file.map(&:size).max.to_s.bytesize
+  convert.size.to_s.rjust(max_lenth)
+end
+
+def timestamp(convert)
+  time_info = convert.mtime
+  time_info.strftime('%_m %_d %_R')
+end
+
+def filename(files, num)
+  files[num]
+end
+
+def print_short_filename(files)
+  row_number = (files.size.to_f / COLUMN_NUMBER).ceil
+  rest_of_row = files.size % COLUMN_NUMBER
+  max_column_width = files.compact.max_by(&:size).size + SPACE
+  filename_with_space = files.map { |space| space.to_s.ljust(max_column_width) }
+  (row_number * COLUMN_NUMBER - files.size).times { filename_with_space.push(nil) } if rest_of_row != 0
+  files_arrays = filename_with_space.each_slice(row_number).to_a
+
+  files_arrays.transpose.each do |index|
+    puts index.join
+  end
+end
+
+main(**option_parse)

--- a/06.wc/2.rb
+++ b/06.wc/2.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'debug'
+require 'date'
+
+COLUMN_NUMBER = 3
+SPACE = 5
+
+def main(**options)
+  files = options[:a] ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+  files = options[:r] ? files.reverse! : files
+  options.key?(:l) ? print_long_filename(files) : print_short_filename(files)
+end
+
+def option_parse
+  options = {}
+  OptionParser.new do |opt|
+    opt.on('-l', '--long', 'long list') { |v| options[:l] = v }
+    opt.on('-a', '--all', 'do not ignore entries starting with .') { |v| options[:a] = v }
+    opt.on('-r', 'reverse', 'reverse the sort order') { |v| options[:r] = v }
+    opt.parse!(ARGV)
+  end
+  options
+end
+
+def print_long_filename(files)
+  stat_file = files.map { |s| File::Stat.new(s) }
+  print_total_blocks(stat_file) if stat_file.size > 1
+  stat_file.each_with_index do |convert, num|
+    filetype(convert)
+    permission(convert)
+    hardlink(stat_file, convert)
+    user(convert)
+    group(convert)
+    filesize(stat_file, convert)
+    timestamp(convert)
+    filename(files, num)
+    puts "#{filetype(convert)}#{permission(convert)} #{hardlink(stat_file, convert)}\
+    #{user(convert)} #{group(convert)}  #{filesize(stat_file, convert)} #{timestamp(convert)} #{filename(files, num)} "
+  end
+end
+
+def print_total_blocks(stat_file)
+  puts "total #{stat_file.map(&:blocks).sum}"
+end
+
+def filetype(convert)
+  filetype_name = convert.ftype
+  filetype_convert_name = { 'fifo' => 'p', 'characterSpecial' => 'c', 'directory' => 'd', 'blockSpecial' => 'b', 'file' => '-', 'link' => 'l',
+                            'socket' => 's' }.freeze
+  filetype_convert_name[filetype_name]
+end
+
+def permission(convert)
+  octal_permission = convert.mode.to_s(8).to_i % 1000
+  octal_permission.to_s.gsub(/[0-7]/, '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx', '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx')
+end
+
+def hardlink(stat_file, convert)
+  max_lenth = stat_file.map(&:nlink).max.to_s.bytesize
+  convert.nlink.to_s.rjust(max_lenth)
+end
+
+def user(convert)
+  user_id = convert.uid
+  Etc.getpwuid(user_id).name
+end
+
+def group(convert)
+  group_id = convert.gid
+  Etc.getgrgid(group_id).name
+end
+
+def filesize(stat_file, convert)
+  max_lenth = stat_file.map(&:size).max.to_s.bytesize
+  convert.size.to_s.rjust(max_lenth)
+end
+
+def timestamp(convert)
+  time_info = convert.mtime
+  time_info.strftime('%_m %_d %_R')
+end
+
+def filename(files, num)
+  files[num]
+end
+
+def print_short_filename(files)
+  row_number = (files.size.to_f / COLUMN_NUMBER).ceil
+  rest_of_row = files.size % COLUMN_NUMBER
+  max_column_width = files.compact.max_by(&:size).size + SPACE
+  filename_with_space = files.map { |space| space.to_s.ljust(max_column_width) }
+  (row_number * COLUMN_NUMBER - files.size).times { filename_with_space.push(nil) } if rest_of_row != 0
+  files_arrays = filename_with_space.each_slice(row_number).to_a
+
+  files_arrays.transpose.each do |index|
+    puts index.join
+  end
+end
+
+main(**option_parse)

--- a/06.wc/3.rb
+++ b/06.wc/3.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'debug'
+require 'date'
+
+COLUMN_NUMBER = 3
+SPACE = 5
+
+def main(**options)
+  files = options[:a] ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+  files = options[:r] ? files.reverse! : files
+  options.key?(:l) ? print_long_filename(files) : print_short_filename(files)
+end
+
+def option_parse
+  options = {}
+  OptionParser.new do |opt|
+    opt.on('-l', '--long', 'long list') { |v| options[:l] = v }
+    opt.on('-a', '--all', 'do not ignore entries starting with .') { |v| options[:a] = v }
+    opt.on('-r', 'reverse', 'reverse the sort order') { |v| options[:r] = v }
+    opt.parse!(ARGV)
+  end
+  options
+end
+
+def print_long_filename(files)
+  stat_file = files.map { |s| File::Stat.new(s) }
+  print_total_blocks(stat_file) if stat_file.size > 1
+  stat_file.each_with_index do |convert, num|
+    filetype(convert)
+    permission(convert)
+    hardlink(stat_file, convert)
+    user(convert)
+    group(convert)
+    filesize(stat_file, convert)
+    timestamp(convert)
+    filename(files, num)
+    puts "#{filetype(convert)}#{permission(convert)} #{hardlink(stat_file, convert)}\
+    #{user(convert)} #{group(convert)}  #{filesize(stat_file, convert)} #{timestamp(convert)} #{filename(files, num)} "
+  end
+end
+
+def print_total_blocks(stat_file)
+  puts "total #{stat_file.map(&:blocks).sum}"
+end
+
+def filetype(convert)
+  filetype_name = convert.ftype
+  filetype_convert_name = { 'fifo' => 'p', 'characterSpecial' => 'c', 'directory' => 'd', 'blockSpecial' => 'b', 'file' => '-', 'link' => 'l',
+                            'socket' => 's' }.freeze
+  filetype_convert_name[filetype_name]
+end
+
+def permission(convert)
+  octal_permission = convert.mode.to_s(8).to_i % 1000
+  octal_permission.to_s.gsub(/[0-7]/, '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx', '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx')
+end
+
+def hardlink(stat_file, convert)
+  max_lenth = stat_file.map(&:nlink).max.to_s.bytesize
+  convert.nlink.to_s.rjust(max_lenth)
+end
+
+def user(convert)
+  user_id = convert.uid
+  Etc.getpwuid(user_id).name
+end
+
+def group(convert)
+  group_id = convert.gid
+  Etc.getgrgid(group_id).name
+end
+
+def filesize(stat_file, convert)
+  max_lenth = stat_file.map(&:size).max.to_s.bytesize
+  convert.size.to_s.rjust(max_lenth)
+end
+
+def timestamp(convert)
+  time_info = convert.mtime
+  time_info.strftime('%_m %_d %_R')
+end
+
+def filename(files, num)
+  files[num]
+end
+
+def print_short_filename(files)
+  row_number = (files.size.to_f / COLUMN_NUMBER).ceil
+  rest_of_row = files.size % COLUMN_NUMBER
+  max_column_width = files.compact.max_by(&:size).size + SPACE
+  filename_with_space = files.map { |space| space.to_s.ljust(max_column_width) }
+  (row_number * COLUMN_NUMBER - files.size).times { filename_with_space.push(nil) } if rest_of_row != 0
+  files_arrays = filename_with_space.each_slice(row_number).to_a
+
+  files_arrays.transpose.each do |index|
+    puts index.join
+  end
+end
+
+main(**option_parse)

--- a/06.wc/ls_ver2.rb
+++ b/06.wc/ls_ver2.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'debug'
+require 'date'
+
+COLUMN_NUMBER = 3
+SPACE = 5
+
+def main(**options)
+  files = options[:a] ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+  files = options[:r] ? files.reverse! : files
+  options.key?(:l) ? print_long_filename(files) : print_short_filename(files)
+end
+
+def option_parse
+  options = {}
+  OptionParser.new do |opt|
+    opt.on('-l', '--long', 'long list') { |v| options[:l] = v }
+    opt.on('-a', '--all', 'do not ignore entries starting with .') { |v| options[:a] = v }
+    opt.on('-r', 'reverse', 'reverse the sort order') { |v| options[:r] = v }
+    opt.parse!(ARGV)
+  end
+  options
+end
+
+def print_long_filename(files)
+  stat_file = files.map { |s| File::Stat.new(s) }
+  print_total_blocks(stat_file) if stat_file.size > 1
+  stat_file.each_with_index do |convert, num|
+    filetype(convert)
+    permission(convert)
+    hardlink(stat_file, convert)
+    user(convert)
+    group(convert)
+    filesize(stat_file, convert)
+    timestamp(convert)
+    filename(files, num)
+    puts "#{filetype(convert)}#{permission(convert)} #{hardlink(stat_file, convert)}\
+    #{user(convert)} #{group(convert)}  #{filesize(stat_file, convert)} #{timestamp(convert)} #{filename(files, num)} "
+  end
+end
+
+def print_total_blocks(stat_file)
+  puts "total #{stat_file.map(&:blocks).sum}"
+end
+
+def filetype(convert)
+  filetype_name = convert.ftype
+  filetype_convert_name = { 'fifo' => 'p', 'characterSpecial' => 'c', 'directory' => 'd', 'blockSpecial' => 'b', 'file' => '-', 'link' => 'l',
+                            'socket' => 's' }.freeze
+  filetype_convert_name[filetype_name]
+end
+
+def permission(convert)
+  octal_permission = convert.mode.to_s(8).to_i % 1000
+  octal_permission.to_s.gsub(/[0-7]/, '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx', '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx')
+end
+
+def hardlink(stat_file, convert)
+  max_lenth = stat_file.map(&:nlink).max.to_s.bytesize
+  convert.nlink.to_s.rjust(max_lenth)
+end
+
+def user(convert)
+  user_id = convert.uid
+  Etc.getpwuid(user_id).name
+end
+
+def group(convert)
+  group_id = convert.gid
+  Etc.getgrgid(group_id).name
+end
+
+def filesize(stat_file, convert)
+  max_lenth = stat_file.map(&:size).max.to_s.bytesize
+  convert.size.to_s.rjust(max_lenth)
+end
+
+def timestamp(convert)
+  time_info = convert.mtime
+  time_info.strftime('%_m %_d %_R')
+end
+
+def filename(files, num)
+  files[num]
+end
+
+def print_short_filename(files)
+  row_number = (files.size.to_f / COLUMN_NUMBER).ceil
+  rest_of_row = files.size % COLUMN_NUMBER
+  max_column_width = files.compact.max_by(&:size).size + SPACE
+  filename_with_space = files.map { |space| space.to_s.ljust(max_column_width) }
+  (row_number * COLUMN_NUMBER - files.size).times { filename_with_space.push(nil) } if rest_of_row != 0
+  files_arrays = filename_with_space.each_slice(row_number).to_a
+
+  files_arrays.transpose.each do |index|
+    puts index.join
+  end
+end
+
+main(**option_parse)

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -10,16 +10,12 @@ def print_result(**options)
   file_name = ARGV[0]
   text = IO.read(file_name)
 
-  print_newline_counts = newline_counts(text) if options[:l]
-  print_word_count = word_counts(text) if options[:w]
-  print_byte_count = byte_count(text) if options[:c]
-  print_file_name = file_name if options[:l] || options[:w] || options[:c]
+  print_newline_counts = newline_counts(text) if options[:l] || options.empty?
+  print_word_count = word_counts(text) if options[:w] || options.empty?
+  print_byte_count = byte_count(text) if options[:c] || options.empty?
+  print_file_name = file_name unless options.empty?
 
-  if options.empty?
-    puts "#{newline_counts(text)} #{word_counts(text)} #{byte_count(text)} #{file_name} "
-  else
-    print "#{print_newline_counts} #{print_word_count} #{print_byte_count} #{print_file_name} \n"
-  end
+  print "#{print_newline_counts} #{print_word_count} #{print_byte_count} #{print_file_name} \n"
 end
 
 def option_parse

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+def main
+  print_result(**option_parse)
+end
+
+def print_result(**options)
+  file_name = ARGV[0]
+  text = IO.read(file_name)
+
+  print_newline_counts = newline_counts(text) if options[:l]
+  print_word_count = word_counts(text) if options[:w]
+  print_byte_count = byte_count(text) if options[:c]
+  print_file_name = file_name if options[:l] || options[:w] || options[:c]
+
+  if options.empty?
+    puts "#{newline_counts(text)} #{word_counts(text)} #{byte_count(text)} #{file_name} "
+  else
+    print "#{print_newline_counts} #{print_word_count} #{print_byte_count} #{print_file_name} \n"
+  end
+end
+
+def option_parse
+  options = {}
+  OptionParser.new do |opt|
+    opt.on('-l', '--lines', 'print the newline counts') { |v| options[:l] = v }
+    opt.on('-w', '--words', 'print the word counts') { |v| options[:w] = v }
+    opt.on('-c', '--bytes', 'print the byte counts') { |v| options[:c] = v }
+    opt.parse!(ARGV)
+  end
+  options
+end
+
+def newline_counts(text)
+  text.count("\n").to_s.rjust(7)
+end
+
+def word_counts(text)
+  text.split.count.to_s.rjust(7)
+end
+
+def byte_count(text)
+  text.bytesize.to_s.rjust(7)
+end
+
+main

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -13,9 +13,8 @@ def print_result(**options)
   print_newline_counts = newline_counts(text) if options[:l] || options.empty?
   print_word_count = word_counts(text) if options[:w] || options.empty?
   print_byte_count = byte_count(text) if options[:c] || options.empty?
-  print_file_name = file_name unless options.empty?
 
-  print "#{print_newline_counts} #{print_word_count} #{print_byte_count} #{print_file_name} \n"
+  print "#{print_newline_counts} #{print_word_count} #{print_byte_count} #{file_name} \n"
 end
 
 def option_parse
@@ -38,7 +37,7 @@ def word_counts(text)
 end
 
 def byte_count(text)
-  text.bytesize.to_s.rjust(7)
+  text.size.to_s.rjust(7)
 end
 
 main

--- a/06.wc/wc_ver2.rb
+++ b/06.wc/wc_ver2.rb
@@ -32,7 +32,6 @@ def option_parse
   options
 end
 
-
 def get_files_data(files_path)
   files_path.map do |file_path|
     content = nil

--- a/06.wc/wc_ver3.rb
+++ b/06.wc/wc_ver3.rb
@@ -2,14 +2,19 @@
 
 require 'optparse'
 require 'readline'
+require 'debug'
 
 def main
   options = option_parse
   options = { l: true, w: true, c: true } if options.empty?
+  binging.break
   
   # 引数の有無を確認する。引数がないときには？
   if ARGV.empty?
     # 引数なし
+    
+
+    p "test"
     read_pipe = $stdin.read
     print_argv_deta(read_pipe, options)
   else
@@ -31,7 +36,6 @@ def option_parse
   end
   options
 end
-
 
 def get_files_data(files_path)
   files_path.map do |file_path|


### PR DESCRIPTION


### 課題
wcコマンドをrubyで書き、Pull Requestとして提出する

### 要件
-`l`、`w`、`c`の各オプションも実装すること。
- 標準入力からも受け取れるようにして実行結果と出力を提出する。
- 引数にファイル名が複数個来た場合にも対応し実行結果と出力を提出する。
- 自作のls -lコマンドと自作のwcコマンドをつなげた出力を提出する。
- wcコマンド側でもl、w、cの各オプションが使えるようにすること
- 本物のls -lコマンド、本物のwcコマンドをつなげた出力を併記して提出すること。
- [rubocop-fjord](https://bootcamp.fjord.jp/pages/292) のチェックが全てパスしたこともスクショで貼り付ける。
どうしても解決できない警告があれば、その理由を書くこと。
- 本物の wc コマンドはノーブレークスペースを含むマルチバイト文字を1単語多くカウントするが、自作の wc コマンドでは対応しなくても良い。

### オプションの指定パターンについて
以下のような指定パターンを一通りサポートできるように実装すること。

- オプションを付けない場合（`wc`）
<img width="299" alt="スクリーンショット 2022-10-17 17 45 27" src="https://user-images.githubusercontent.com/90853054/196222939-dcdd6fb3-3f9d-4433-9e89-947156dcb732.png">


- オプションを1つ付ける場合（`wc -l`、`wc -w`、`wc -c`）

<img width="312" alt="スクリーンショット 2022-10-17 17 50 59" src="https://user-images.githubusercontent.com/90853054/196224219-d677b3f1-b8d1-4e04-91f8-23e0de849015.png">


- オプションを2つ付ける場合（`wc -lw`、`wc -wc`、`wc -lc`）
<img width="375" alt="スクリーンショット 2022-10-17 17 48 47" src="https://user-images.githubusercontent.com/90853054/196223790-f704fe78-617b-4b60-8b3c-58efb09147d2.png">

- オプションを3つ全部付ける場合（`wc -lwc`）
<img width="345" alt="スクリーンショット 2022-10-17 17 53 54" src="https://user-images.githubusercontent.com/90853054/196224873-e57f4fc0-c358-4723-9391-65913d5d4672.png">

### rubocop
<img width="442" alt="スクリーンショット 2022-10-18 11 21 56" src="https://user-images.githubusercontent.com/90853054/196391098-23d73609-7419-42cc-bcf2-fdaf167ab3a5.png">

